### PR TITLE
Changed JS CDN

### DIFF
--- a/_data/variables.yml
+++ b/_data/variables.yml
@@ -13,7 +13,7 @@ default:
   chart: false
   toc:
     selectors: 'h1,h2,h3'
-  sources: bootcdn
+  sources: unpkg
 
   page:
     mode: normal


### PR DESCRIPTION
Current default CDN for jquery (`https://cdn.bootcss.com/jquery/3.1.1/jquery.min.js`), Chart.js (`https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js`) and Mermaid.js (`https://cdn.bootcss.com/mermaid/8.0.0-rc.8/mermaid.min.js`) takes forever to load (est 20s, 50s and 3.5min when tested).

Noticed that unpkg CDN links were already included in the project and when tested, performed much better.